### PR TITLE
Fix warnings and add regression test

### DIFF
--- a/R/style_catalogue.R
+++ b/R/style_catalogue.R
@@ -44,7 +44,7 @@ style_catalogue_xlsx_import <- function(tab, path) {
     for (iter in 1:length(i$rows)){
       r <- i$rows[iter]
       c <- i$cols[iter]
-      cell <- openxlsx::readWorkbook(wb, rows = r, cols = c, colNames = FALSE, rowNames = FALSE)
+      suppressWarnings(cell <- openxlsx::readWorkbook(wb, rows = r, cols = c, colNames = FALSE, rowNames = FALSE))
 
       value <- cell[1, 1]
 
@@ -118,8 +118,7 @@ create_style_key <- function(style_list){
                         property_to_key(style_list, "textDecoration"),
                         property_to_key(style_list, "wrapText"),
                         property_to_key(style_list, "textRotation"),
-                        property_to_key(style_list, "indent"),
-                        property_to_key(style_list, "rowHeight"))
+                        property_to_key(style_list, "indent"))
 
   style_key <- paste(style_properties, collapse = "|")
 

--- a/tests/testthat/test_regressions.R
+++ b/tests/testthat/test_regressions.R
@@ -14,3 +14,14 @@ test_that("test styles table does not have factors", {
   t1 = (class(df$style_name) == "character")
   testthat::expect_true(t1)
 })
+
+
+test_that("test no warning are issued from style_catalogue_xlsx_import", {
+
+  path <- system.file("extdata", "styles_pub.xlsx", package = "xltabr")
+  tab <- list()
+
+  # Expect no warning is issued https://stackoverflow.com/questions/22003306/is-there-something-in-testthat-like-expect-no-warnings
+  expect_warning(xltabr:::style_catalogue_xlsx_import(tab, path), regexp = NA)
+
+})


### PR DESCRIPTION
Fixes #34 - issue was that openxlsx issues a warning when you read in a cell reference that contains no data.