### PR TITLE
Onload patch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xltabr
 Type: Package
 Title: Automatically Write Beautifully Formatted Cross Tabulations/Contingency Tables to Excel
-Version: 0.1.1
+Version: 0.1.2.9000
 Authors@R: c(
     person("Robin", "Linacre", , "robinlinacre@hotmail.com",
     role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xltabr
 Type: Package
 Title: Automatically Write Beautifully Formatted Cross Tabulations/Contingency Tables to Excel
-Version: 0.1.2.9000
+Version: 0.1.2
 Authors@R: c(
     person("Robin", "Linacre", , "robinlinacre@hotmail.com",
     role = c("aut", "cre")),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,13 +1,14 @@
-xltabr_default_options <- list(
-  xltabr.style.path = system.file("extdata", "styles.xlsx", package = "xltabr"),
-  xltabr.cell.format.path = system.file("extdata", "style_to_excel_number_format.csv", package = "xltabr"),
-  xltabr.number.format.path = system.file("extdata", "number_format_defaults.csv", package = "xltabr"),
-  xltabr.style.override.path = NULL)
-
 .onLoad <- function(libname, pkgname) {
+
+  xltabr_default_options <- list(
+    xltabr.style.path = system.file("extdata", "styles.xlsx", package = "xltabr"),
+    xltabr.cell.format.path = system.file("extdata", "style_to_excel_number_format.csv", package = "xltabr"),
+    xltabr.number.format.path = system.file("extdata", "number_format_defaults.csv", package = "xltabr"),
+    xltabr.style.override.path = NULL)
+
   op <- options()
   toset <- !(names(xltabr_default_options) %in% names(op))
-  if(any(toset)) options(xltabr_default_options[toset])
+  if (any(toset)) options(xltabr_default_options[toset])
 
   invisible()
 }


### PR DESCRIPTION
Moving xltabr_default_options inside scope of .onload. 

Have checked with build with binary and seems to remove xltabr_default_options to lazy load db (xltabr.rdb).

This should fix issue #108 